### PR TITLE
Accept multiple TSIG keys

### DIFF
--- a/bind9_parser/isc_clause_key.py
+++ b/bind9_parser/isc_clause_key.py
@@ -49,7 +49,7 @@ clause_stmt_key_standalone = (
         + rbrack
     )
     + semicolon
-)('key')
+)('key*')
 
 # {0-*} statement
 clause_stmt_key_series = (


### PR DESCRIPTION
This one-character fix ensures that the bind9_parser handles multiple TSIG keys correctly.

Closes #48

Signed-off-by: Stephan Austermühle <au@hcsd.de>